### PR TITLE
Fix validateAll

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "prop-types": "^15.5.10",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
+    "react-test-renderer": "^15.6.1",
     "rimraf": "^2.6.1",
     "rollup": "^0.42.0",
     "rollup-plugin-babel": "^2.7.1",

--- a/src/React/index.js
+++ b/src/React/index.js
@@ -79,11 +79,10 @@ function Revalidation(
     }
 
     validateAll(cb: Function, data: Object): void {
-      const { form, errors } = this.state
       this.setState(state => {
         const updateErrors = validate(prop('form', state), validationRules)
         return assoc('errors', updateErrors, state)
-      }, () => { if (isValid(errors) && cb) cb(data || form) })
+      }, () => { if (isValid(this.state.errors) && cb) cb(data || this.state.form) })
     }
 
     render() {

--- a/test/React/index.test.js
+++ b/test/React/index.test.js
@@ -1,0 +1,62 @@
+/* eslint-env mocha */
+
+import { equal } from 'assert'
+import React from 'react' // eslint-disable-line no-unused-vars
+import ShallowRenderer from 'react-test-renderer/shallow'
+import Revalidation from '../../src'
+
+const isNotEmpty = a => a.trim().length > 0
+
+const getValue = e => e.target.value
+
+const validationRules = {
+  name: [[isNotEmpty, 'Name should not be empty']],
+}
+
+const ErrorComponent = ({ errorMsgs }) =>
+  <div className='error'>{errorMsgs && errorMsgs[0]}</div>
+
+const Form = ({
+  reValidation: { form, validate, errors = {}, validateAll },
+  onSubmit,
+}) =>
+  <div className='form'>
+    <div className='formGroup'>
+      <label>Name</label>
+      <input
+        type='text'
+        value={form.name}
+        onChange={e => validate('name', getValue(e))}
+      />
+      {errors.name}
+    </div>
+    <button onClick={() => validateAll(onSubmit)}>Submit</button>
+  </div>
+
+const initialState = { name: '' }
+
+const enhanced = Revalidation(
+  initialState,
+  validationRules,
+  ErrorComponent,
+  { validateSingle: false },
+)
+
+const EnhancedForm = enhanced(Form) // eslint-disable-line no-unused-vars
+
+describe('React/index', () => {
+  it('callback passed to `validateAll` is not called when the form has errors', () => {
+    const renderer = new ShallowRenderer()
+    let wasCallbackCalled = false
+    renderer.render(
+      <EnhancedForm
+        onSubmit={() => {
+          wasCallbackCalled = true
+        }}
+      />,
+    )
+    const output = renderer.getRenderOutput()
+    output.props.reValidation.validateAll(output.props.onSubmit)
+    equal(wasCallbackCalled, false)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2839,6 +2839,13 @@ react-dom@^15.5.4:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
+react-test-renderer@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.1.tgz#026f4a5bb5552661fd2cc4bbcd0d4bc8a35ebf7e"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
+
 react@^15.5.4:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"


### PR DESCRIPTION
Currently, the callback passed to `validateAll` is called even if the form has errors.

The first commit adds a failing test that demonstrates this to be the case. The second commit adds the fix.

Since there weren't any existing tests for the HOC to reference, let me know if you want things to be done differently for the test. Lint passes for the test file I added, although there are 7 existing lint errors on the master branch.