### PR TITLE
Allow passing a function for error message

### DIFF
--- a/src/createValidation.js
+++ b/src/createValidation.js
@@ -53,9 +53,9 @@ const createBaseValidation = (input, validations) =>
  * if predicate function is truthy an Either.Right is rerturned else an Else.Left
  *
  * @param {Function} predFn the predicate function to be run
- * @param {string} e the error message
+ * @param {string|Function} e the error message or a function that returns the error message
  */
-const makePredicate = ([predFn, e]) => (a, inputs) => predFn(a, inputs) ? Left(a) : Right(e)
+const makePredicate = ([predFn, e]) => (a, inputs) => predFn(a, inputs) ? Left(a) : Right(typeof e === 'function' ? e(a) : e)
 
 /**
  * applies all predicates with the input value and inputs objects

--- a/test/createValidation.test.js
+++ b/test/createValidation.test.js
@@ -28,6 +28,7 @@ const isEqual = compareKey => (a, all) => a === all[compareKey]
 const notEmptyMsg = field => `${field} should not be empty.`
 const minimumMsg = (field, len) => `Minimum ${field} length of ${len} is required.`
 const capitalLetterMag = field => `${field} should contain at least one uppercase letter.`
+const capitalLetterMsgWithValue = (field) => (value) => `${field} should contain at least one uppercase letter. ${value} is missing an uppercase letter.`
 const equalMsg = (field1, field2) => `${field2} should be equal with ${field1}`
 
 // Rules
@@ -157,4 +158,11 @@ describe('Validator', () => {
     deepEqual({password: true}, result)
   })
 
+  it('should pass the value to the error message if it is a function', () => {
+    const validationRules = {
+      password: [[hasCapitalLetter, capitalLetterMsgWithValue('Password')]],
+    }
+    const result = validate({ password: 'foobar' }, validationRules)
+    deepEqual({ password: 'Password should contain at least one uppercase letter. foobar is missing an uppercase letter.' }, result)
+  })
 })


### PR DESCRIPTION
Thought I'd open this PR for discussion.

Sometimes, it's desirable to include the input value in the error message. This PR modifies `makePredicate` in `createValidation` so that if the second value of the tuple is a function, it is called with the input value.

If you're on board with this, I'm happy to make changes/additions to the documentation as well if needed.